### PR TITLE
feat: adding pagination to alert location response

### DIFF
--- a/getOrgSecretAlerts.js
+++ b/getOrgSecretAlerts.js
@@ -49,28 +49,31 @@ async function getOrgSecretAlerts() {
     const records = [];
     let counter = 1; // Initialize counter
 
-    for (const alert of alerts) {
+    for (let i = 0; i < alerts.length; i++) {
+      const alert = alerts[i];
+      console.log(`Processing alert ${i + 1} of ${alerts.length}`);
+
       if (!alert.locations_url) {
         console.log(`Alert ${alert.number} is missing locations_url`);
         continue;
       }
 
-      console.log(`Processing alert ${alert.number}`);
-      let locationResponse;
+      let locations;
       try {
-        locationResponse = await octokit.request(`GET ${alert.locations_url}`, {
+        locations = await octokit.paginate(`GET ${alert.locations_url}`, {
           headers: {
             'X-GitHub-Api-Version': '2022-11-28'
-          }
+          },
+          per_page: 100
         });
       } catch (error) {
         console.error(`Failed to fetch locations for alert ${alert.number}:`, error);
         continue;
       }
 
-      console.log(`Location Response: ${JSON.stringify(locationResponse, null, 2)}`);
+      console.log(`Locations: ${JSON.stringify(locations, null, 2)}`);
 
-      locationResponse.data.forEach(location => {
+      locations.forEach(location => {
         let url;
         let path;
 


### PR DESCRIPTION
Enhancements to logging and loop structure:

* [`getOrgSecretAlerts.js`](diffhunk://#diff-d894ecba6a116f2d0a4d221ce9b6a46e8f1c36ac8b221ffa9dd05c36e95bfaadL52-R76): Replaced the `for...of` loop with a `for` loop with indexing to add more detailed logging, including the current alert number and total alerts being processed. (`[getOrgSecretAlerts.jsL52-R76](diffhunk://#diff-d894ecba6a116f2d0a4d221ce9b6a46e8f1c36ac8b221ffa9dd05c36e95bfaadL52-R76)`)
* [`getOrgSecretAlerts.js`](diffhunk://#diff-d894ecba6a116f2d0a4d221ce9b6a46e8f1c36ac8b221ffa9dd05c36e95bfaadL52-R76): Added a log statement to indicate the start of processing for each alert, including its index and total count. (`[getOrgSecretAlerts.jsL52-R76](diffhunk://#diff-d894ecba6a116f2d0a4d221ce9b6a46e8f1c36ac8b221ffa9dd05c36e95bfaadL52-R76)`)

Improvements to API request handling:

* [`getOrgSecretAlerts.js`](diffhunk://#diff-d894ecba6a116f2d0a4d221ce9b6a46e8f1c36ac8b221ffa9dd05c36e95bfaadL52-R76): Changed the API request method from `octokit.request` to `octokit.paginate` to handle paginated responses and added a `per_page` parameter to specify the number of items per page. (`[getOrgSecretAlerts.jsL52-R76](diffhunk://#diff-d894ecba6a116f2d0a4d221ce9b6a46e8f1c36ac8b221ffa9dd05c36e95bfaadL52-R76)`)
* [`getOrgSecretAlerts.js`](diffhunk://#diff-d894ecba6a116f2d0a4d221ce9b6a46e8f1c36ac8b221ffa9dd05c36e95bfaadL52-R76): Updated the log statement to print the fetched locations instead of the location response. (`[getOrgSecretAlerts.jsL52-R76](diffhunk://#diff-d894ecba6a116f2d0a4d221ce9b6a46e8f1c36ac8b221ffa9dd05c36e95bfaadL52-R76)`)